### PR TITLE
Fix: Missing painting logic for Vanessa's Manor in moderate and higher logic difficulty

### DIFF
--- a/worlds/ahit/Rules.py
+++ b/worlds/ahit/Rules.py
@@ -432,9 +432,10 @@ def set_moderate_rules(world: "HatInTimeWorld"):
 
     # Moderate: Vanessa Manor with nothing
     for loc in world.multiworld.get_region("Queen Vanessa's Manor", world.player).locations:
-        set_rule(loc, lambda state: True)
+        set_rule(loc, lambda state: has_paintings(state, world, 1))
 
-    set_rule(world.multiworld.get_location("Subcon Forest - Manor Rooftop", world.player), lambda state: True)
+    set_rule(world.multiworld.get_location("Subcon Forest - Manor Rooftop", world.player),
+             lambda state: has_paintings(state, world, 1))
 
     # Moderate: get to Birdhouse/Yellow Band Hills without Brewing Hat
     set_rule(world.multiworld.get_entrance("-> The Birdhouse", world.player),


### PR DESCRIPTION
When `NoPaintingSkips` is enabled in moderate logic difficulty and
higher, Vanessa's Manor cannot logically be reached until the first
Progressive Painting has been acquired, but the logic was setting
Vanessa's Manor to always be considered accessible.

This patch adds the missing checks for having the first Progressive
Painting when `NoPaintingSkips` is enabled.